### PR TITLE
Strip mirrors with IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<<<<<<< HEAD
+=======
+### Changed
+- Remove mirror classes during IR generation
+
+>>>>>>> b6bec2a (Strip mirrors with IR)
 ## [0.1.0]
 
 ### Added

--- a/annotations/src/main/resources/META-INF/proguard/autoservice-annotations.pro
+++ b/annotations/src/main/resources/META-INF/proguard/autoservice-annotations.pro
@@ -18,9 +18,3 @@
 -keep @com.google.auto.service.AutoService class * {
     <init>();
 }
-
-# Remove synthetic __AutoService__ mirror classes used for incremental compilation.
-# These classes are marked @Deprecated(level = HIDDEN) and serve no purpose at runtime.
--assumenosideeffects class **$__AutoService__ {
-    *;
-}

--- a/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/ir/AutoServiceIrGenerationExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/ir/AutoServiceIrGenerationExtension.kt
@@ -1,7 +1,9 @@
 package com.fueledbycaffeine.autoservice.ir
 
+import com.fueledbycaffeine.autoservice.AutoServiceSymbols
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import java.nio.file.Path
@@ -28,5 +30,42 @@ internal class AutoServiceIrGenerationExtension(
         )
       moduleFragment.accept(autoServiceVisitor, null)
     }
+    
+    // Strip synthetic __AutoService__ mirror classes - they were only needed for FIR
+    // incremental compilation tracking and serve no purpose in the final bytecode.
+    stripMirrorClasses(moduleFragment, debugLogger)
+  }
+  
+  @OptIn(UnsafeDuringIrConstructionAPI::class)
+  private fun stripMirrorClasses(moduleFragment: IrModuleFragment, debugLogger: AutoServiceDebugLogger) {
+    val topLevelClasses = moduleFragment.files.flatMap { file ->
+      file.declarations.filterIsInstance<IrClass>()
+    }
+    stripMirrorClassesFromClasses(topLevelClasses, debugLogger)
+  }
+
+  @OptIn(UnsafeDuringIrConstructionAPI::class)
+  private tailrec fun stripMirrorClassesFromClasses(
+    pending: List<IrClass>,
+    debugLogger: AutoServiceDebugLogger,
+  ) {
+    if (pending.isEmpty()) return
+
+    val irClass = pending.first()
+    val rest = pending.drop(1)
+
+    // Remove __AutoService__ nested classes
+    val mirrorsToRemove = irClass.declarations.filterIsInstance<IrClass>()
+      .filter { it.name == AutoServiceSymbols.Names.MIRROR_CLASS }
+
+    for (mirror in mirrorsToRemove) {
+      debugLogger.log("Stripping mirror class: ${irClass.name}\$${mirror.name}")
+      irClass.declarations.remove(mirror)
+    }
+
+    // Add remaining nested classes to the pending list
+    val nestedClasses = irClass.declarations.filterIsInstance<IrClass>()
+
+    stripMirrorClassesFromClasses(rest + nestedClasses, debugLogger)
   }
 }


### PR DESCRIPTION
The FIR generated mirrors are never needed outside of the context of the one module so we can delete them completely before they reach bytecode