### PR TITLE
Share service metadata from FIR to IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<<<<<<< HEAD
-=======
 ### Changed
+- Generate metadata about service classes during FIR using `FirDeclarationDataRegistry` so that IR can read them directly instead of reparsing the `@AutoService` annotations and classes.
 - Remove mirror classes during IR generation
 
->>>>>>> b6bec2a (Strip mirrors with IR)
 ## [0.1.0]
 
 ### Added

--- a/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/AutoServiceSymbols.kt
+++ b/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/AutoServiceSymbols.kt
@@ -46,11 +46,5 @@ internal object AutoServiceSymbols {
      * Name of the synthetic mirror class generated for incremental compilation support.
      */
     val MIRROR_CLASS: Name = Name.identifier("__AutoService__")
-    
-    /**
-     * Name of the synthetic property that stores resolved service interfaces.
-     * This is generated in FIR and consumed in IR.
-     */
-    val SERVICE_INTERFACES: Name = Name.identifier("__autoServiceInterfaces__")
   }
 }

--- a/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/fir/AutoServiceMetadata.kt
+++ b/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/fir/AutoServiceMetadata.kt
@@ -1,0 +1,48 @@
+package com.fueledbycaffeine.autoservice.fir
+
+import org.jetbrains.kotlin.fir.backend.FirMetadataSource
+import org.jetbrains.kotlin.fir.declarations.FirClass
+import org.jetbrains.kotlin.fir.declarations.FirDeclarationDataKey
+import org.jetbrains.kotlin.fir.declarations.FirDeclarationDataRegistry
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.name.ClassId
+
+/**
+ * Metadata about @AutoService annotations, computed during FIR phase and consumed in IR phase.
+ * 
+ * This avoids duplicating the service interface inference logic in IR by having FIR
+ * store the resolved service interfaces directly on the class declaration.
+ *
+ * @property serviceInterfaces The list of service interface ClassIds that this class provides.
+ *                             Empty list means the class is not annotated with @AutoService.
+ */
+internal data class AutoServiceMetadata(
+  val serviceInterfaces: List<ClassId>,
+)
+
+/**
+ * Key for storing [AutoServiceMetadata] on FIR class declarations.
+ */
+internal object AutoServiceMetadataKey : FirDeclarationDataKey()
+
+/**
+ * Extension property to get/set [AutoServiceMetadata] on a [FirClass].
+ */
+internal var FirClass.autoServiceMetadata: AutoServiceMetadata?
+  by FirDeclarationDataRegistry.data(AutoServiceMetadataKey)
+
+/**
+ * Extension property to read [AutoServiceMetadata] from an [IrClass] via its FIR metadata.
+ * 
+ * This allows IR to access the service interface information computed during FIR phase
+ * without reparsing annotations or re-inferring types.
+ * 
+ * @return The [AutoServiceMetadata] if available, or null if the class has no FIR metadata
+ *         or was not processed by AutoService FIR extensions.
+ */
+internal val IrClass.autoServiceMetadata: AutoServiceMetadata?
+  get() {
+    val firMetadata = metadata as? FirMetadataSource.Class ?: return null
+    return firMetadata.fir.autoServiceMetadata
+  }
+

--- a/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/fir/AutoServiceMirrorFirGenerator.kt
+++ b/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/fir/AutoServiceMirrorFirGenerator.kt
@@ -89,13 +89,17 @@ internal class AutoServiceMirrorFirGenerator(session: FirSession) : FirDeclarati
     classSymbol: FirClassSymbol<*>,
     context: NestedClassGenerationContext,
   ): Set<Name> {
-    val annotation = classSymbol.fir.annotations.firstOrNull { annotation ->
+    val firClass = classSymbol.fir
+    val annotation = firClass.annotations.firstOrNull { annotation ->
       isAutoServiceAnnotation(annotation.annotationTypeRef)
     }
     
     if (annotation == null) {
       return emptySet()
     }
+
+    // Note: Service interfaces metadata is stored by AutoServiceClassChecker
+    // which runs after types are resolved. We just generate the mirror class here.
 
     val mirrorClassId = classSymbol.classId.createNestedClassId(AutoServiceSymbols.Names.MIRROR_CLASS)
     mirrorClassesToGenerate.add(mirrorClassId)


### PR DESCRIPTION
Generate metadata about service classes during FIR using FirDeclarationDataRegistry so that IR can read them directly instead of reparsing the @AutoService annotations and classes.

See also https://github.com/ZacSweers/metro/issues/1775