### PR TITLE
Align Kotlin version overrides and CI for 2.4.0-Beta1

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,6 +38,8 @@ jobs:
       matrix:
         kotlin_version:
           - 2.3.10
+          - 2.3.20
+          - 2.4.0-Beta1
         gradle_version:
           - 8.14.3
           - 9.4.0
@@ -81,6 +83,7 @@ jobs:
         kotlin_version:
           - 2.3.10
           - 2.3.20
+          - 2.4.0-Beta1
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/build-logic/conventions/build.gradle.kts
+++ b/build-logic/conventions/build.gradle.kts
@@ -3,6 +3,19 @@ plugins {
   id("java-gradle-plugin")
 }
 
+val defaultKotlinVersion = libs.versions.kotlin.get()
+val effectiveKotlinVersion: String = System.getProperty("kotlinVersion") ?: defaultKotlinVersion
+
+if (effectiveKotlinVersion != defaultKotlinVersion) {
+  configurations.configureEach {
+    resolutionStrategy.eachDependency {
+      if (requested.group == "org.jetbrains.kotlin") {
+        useVersion(effectiveKotlinVersion)
+      }
+    }
+  }
+}
+
 kotlin {
   jvmToolchain(21)
 }

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
     gradlePluginPortal()
   }
   plugins {
-    id("org.jetbrains.kotlin.jvm") version "2.3.0"
+    id("org.jetbrains.kotlin.jvm") version (System.getProperty("kotlinVersion") ?: "2.3.0")
   }
 }
 

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -9,19 +9,22 @@ val defaultKotlinVersion = libs.versions.kotlin.get()
 val effectiveKotlinVersion: String = System.getProperty("kotlinVersion") ?: defaultKotlinVersion
 
 val kotlinVersionParts = effectiveKotlinVersion.split("-")[0].split(".").map { it.toInt() }
-val isKotlin2320OrLater = kotlinVersionParts[0] > 2 ||
-  (kotlinVersionParts[0] == 2 && kotlinVersionParts[1] > 3) ||
-  (kotlinVersionParts[0] == 2 && kotlinVersionParts[1] == 3 && kotlinVersionParts[2] >= 20)
+
+fun isAtLeastKotlinVersion(major: Int, minor: Int, patch: Int): Boolean =
+  kotlinVersionParts[0] > major ||
+    (kotlinVersionParts[0] == major && kotlinVersionParts[1] > minor) ||
+    (kotlinVersionParts[0] == major &&
+      kotlinVersionParts[1] == minor &&
+      kotlinVersionParts[2] >= patch)
 
 // When testing against a non-default Kotlin version, substitute all org.jetbrains.kotlin
-// dependencies in test-related configurations so the compiler test framework matches.
+// dependencies in this project so the compiler plugin and test framework compile against
+// the same Kotlin API level.
 if (effectiveKotlinVersion != defaultKotlinVersion) {
   configurations.configureEach {
-    if (name.startsWith("test", ignoreCase = true)) {
-      resolutionStrategy.eachDependency {
-        if (requested.group == "org.jetbrains.kotlin") {
-          useVersion(effectiveKotlinVersion)
-        }
+    resolutionStrategy.eachDependency {
+      if (requested.group == "org.jetbrains.kotlin") {
+        useVersion(effectiveKotlinVersion)
       }
     }
   }
@@ -34,7 +37,12 @@ sourceSets {
     resources.setSrcDirs(listOf("testData"))
   }
   named("testFixtures") {
-    val versionSpecificDir = if (isKotlin2320OrLater) "kotlin-2.3.20" else "kotlin-pre-2.3.20"
+    val versionSpecificDir =
+      when {
+        isAtLeastKotlinVersion(2, 4, 0) -> "kotlin-2.4.0"
+        isAtLeastKotlinVersion(2, 3, 20) -> "kotlin-2.3.20"
+        else -> "kotlin-pre-2.3.20"
+      }
     kotlin.srcDir("src/testFixtures/$versionSpecificDir")
   }
 }
@@ -43,10 +51,11 @@ idea { module.generatedSourceDirs.add(projectDir.resolve("test-gen/java")) }
 
 kotlin {
   compilerOptions {
-    freeCompilerArgs.addAll(
-      "-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi",
-      "-Xcontext-parameters"
-    )
+    freeCompilerArgs.add("-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi")
+
+    if (!isAtLeastKotlinVersion(2, 4, 0)) {
+      freeCompilerArgs.add("-Xcontext-parameters")
+    }
   }
 }
 

--- a/compiler-plugin/src/testFixtures/kotlin-2.3.20/com/fueledbycaffeine/autoservice/compiler/ClasspathBasedStandardLibrariesPathProvider.kt
+++ b/compiler-plugin/src/testFixtures/kotlin-2.3.20/com/fueledbycaffeine/autoservice/compiler/ClasspathBasedStandardLibrariesPathProvider.kt
@@ -1,5 +1,3 @@
-// Copyright (C) 2024 FueledByCaffeine
-// SPDX-License-Identifier: Apache-2.0
 package com.fueledbycaffeine.autoservice.compiler
 
 import java.io.File

--- a/compiler-plugin/src/testFixtures/kotlin-2.4.0/com/fueledbycaffeine/autoservice/compiler/ClasspathBasedStandardLibrariesPathProvider.kt
+++ b/compiler-plugin/src/testFixtures/kotlin-2.4.0/com/fueledbycaffeine/autoservice/compiler/ClasspathBasedStandardLibrariesPathProvider.kt
@@ -1,11 +1,14 @@
+// Copyright (C) 2024 FueledByCaffeine
+// SPDX-License-Identifier: Apache-2.0
 package com.fueledbycaffeine.autoservice.compiler
 
 import java.io.File
 import java.io.File.pathSeparator
 import java.io.File.separator
+import org.jetbrains.kotlin.platform.wasm.WasmTarget
 import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
 
-object ClasspathBasedStandardLibrariesPathProvider : KotlinStandardLibrariesPathProvider() {
+object ClasspathBasedStandardLibrariesPathProvider : KotlinStandardLibrariesPathProvider {
   private val SEP = "\\$separator"
 
   private val GRADLE_DEPENDENCY =
@@ -29,9 +32,9 @@ object ClasspathBasedStandardLibrariesPathProvider : KotlinStandardLibrariesPath
         GRADLE_DEPENDENCY.matchEntire(it.path)?.let { it.groups["name"]!!.value } ?: it.name
       }
 
-  private fun getFile(name: String): File {
-    return jars[name]
-      ?: error("Jar $name not found in classpath:\n${jars.entries.joinToString("\n")}")
+  private fun getFile(vararg names: String): File {
+    return names.firstNotNullOfOrNull(jars::get)
+      ?: error("Jar ${names.joinToString(" or ")} not found in classpath:\n${jars.entries.joinToString("\n")}")
   }
 
   override fun runtimeJarForTests(): File = getFile("kotlin-stdlib")
@@ -50,15 +53,25 @@ object ClasspathBasedStandardLibrariesPathProvider : KotlinStandardLibrariesPath
 
   override fun getAnnotationsJar(): File = getFile("kotlin-annotations-jvm")
 
-  override fun fullJsStdlib(): File = getFile("kotlin-stdlib-js")
+  override fun fullJsStdlib(): File = getFile("kotlin-stdlib-js.klib", "kotlin-stdlib-js")
 
-  override fun defaultJsStdlib(): File = getFile("kotlin-stdlib-js")
+  override fun defaultJsStdlib(): File = getFile("kotlin-stdlib-js.klib", "kotlin-stdlib-js")
 
-  override fun kotlinTestJsKLib(): File = getFile("kotlin-test-js")
+  override fun kotlinTestJsKLib(): File = getFile("kotlin-test-js.klib", "kotlin-test-js")
+
+  override fun fullWasmStdlib(target: WasmTarget): File =
+    getFile("kotlin-stdlib-${target.alias}.klib", "kotlin-stdlib-${target.alias}")
+
+  override fun kotlinTestWasmKLib(target: WasmTarget): File =
+    getFile("kotlin-test-${target.alias}.klib", "kotlin-test-${target.alias}")
+
+  override fun webStdlibForTests(): File =
+    getFile("kotlin-stdlib-wasm-js.klib", "kotlin-stdlib-wasm-js")
 
   override fun scriptingPluginFilesForTests(): Collection<File> {
     TODO("KT-67573")
   }
 
-  override fun commonStdlibForTests(): File = getFile("kotlin-common-stdlib")
+  override fun commonStdlibForTests(): File =
+    getFile("kotlin-common-stdlib.klib", "kotlin-common-stdlib")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@ pluginManagement {
   plugins {
     id("com.gradle.develocity") version "4.3"
     id("com.gradle.plugin-publish") version "1.3.1"
-    id("org.jetbrains.kotlin.jvm") version "2.3.0"
+    id("org.jetbrains.kotlin.jvm") version (System.getProperty("kotlinVersion") ?: "2.3.0")
     id("com.autonomousapps.build-health") version "3.5.1"
     id("com.autonomousapps.testkit") version "0.14"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.17.0"


### PR DESCRIPTION
Propagate `-DkotlinVersion` through settings, build-logic, and the compiler-plugin build so the plugin and compiler test framework compile against the same Kotlin API level under version-matrix tests.

Add a dedicated `kotlin-2.4.0` test-fixture implementation of `ClasspathBasedStandardLibrariesPathProvider` for the Kotlin 2.4 test framework API, and extend the GitHub Actions matrix to cover Kotlin 2.4.0-Beta1.