### PR TITLE
Fix binary compatibility across Kotlin 2.3 and 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Register compiler extensions reflectively so a single published artifact works with both Kotlin 2.3.x and 2.4 compilers
+
 ## [0.1.5]
 
 ### Changed

--- a/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/ir/AutoServiceComponentRegistrar.kt
+++ b/compiler-plugin/src/main/kotlin/com/fueledbycaffeine/autoservice/ir/AutoServiceComponentRegistrar.kt
@@ -34,12 +34,24 @@ public class AutoServiceComponentRegistrar : CompilerPluginRegistrar() {
     }
     val debugLogDir = configuration[KEY_DEBUG_LOG_DIR]?.let { Path.of(it) }
 
-    // Register FIR extension for IC support via synthetic mirror declarations
-    FirExtensionRegistrarAdapter.registerExtension(AutoServiceFirExtensionRegistrar())
+    // Register FIR extension for diagnostics
+    registerExtensionCompat(FirExtensionRegistrarAdapter.Companion, AutoServiceFirExtensionRegistrar())
 
     // Register IR extension for service file generation
-    IrGenerationExtension.registerExtension(
-      AutoServiceIrGenerationExtension(outputDir, debugLogDir)
+    registerExtensionCompat(
+      IrGenerationExtension.Companion,
+      AutoServiceIrGenerationExtension(outputDir, debugLogDir),
     )
+  }
+
+  /**
+   * Registers an extension via reflection so a single published artifact stays binary compatible
+   * across Kotlin versions. The receiver type of [ExtensionStorage.registerExtension] changed in
+   * Kotlin 2.4 from `ProjectExtensionDescriptor` to `ExtensionPointDescriptor`, so a direct call
+   * binds to a method/class that does not exist in the other version's compiler.
+   */
+  private fun ExtensionStorage.registerExtensionCompat(descriptor: Any, extension: Any) {
+    val method = javaClass.methods.first { it.name == "registerExtension" && it.parameterCount == 2 }
+    method.invoke(this, descriptor, extension)
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,4 +7,4 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 
 GROUP=com.fueledbycaffeine.autoservice
-VERSION_NAME=0.1.5
+VERSION_NAME=0.1.6-SNAPSHOT


### PR DESCRIPTION
The 0.1.5 artifact is compiled against Kotlin 2.4 and crashes under Kotlin 2.3.x consumers with NoClassDefFoundError for ExtensionPointDescriptor. ExtensionStorage.registerExtension changed its receiver type in 2.4 (ProjectExtensionDescriptor to ExtensionPointDescriptor), so a jar compiled against one version cannot load under the other. Register the FIR and IR extensions reflectively so a single published jar works with both. Verified by compiling a Kotlin 2.3.21 consumer against the 2.4-built plugin.